### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setuptools.setup(
     description="Python wrapper around mullvad api",
     long_description=long_description,
     long_description_content_type="text/markdown",
+    license="MIT",
     install_requires=["requests"],
     py_modules=["mullvad_api"],
     classifiers=[


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.